### PR TITLE
Exclude Okta /mellon path from rewrites

### DIFF
--- a/htdocs/htaccess-dist
+++ b/htdocs/htaccess-dist
@@ -10,6 +10,9 @@ RewriteRule ^(application|modules|system) - [F,L]
 # Protect *-dist files
 RewriteRule -dist$ - [F,L]
 
+# Exclude Okta /mellon authentication stuff from rewrites
+RewriteRule ^mellon($|/) - [L]
+
 # Allow any files or directories that exist to be displayed directly
 RewriteCond %{REQUEST_FILENAME} !-f
 RewriteCond %{REQUEST_FILENAME} !-d


### PR DESCRIPTION
In order to support Okta SSO, the /mellon path needs to be excluded from any Apache rewrites.  Without this, the app redirects endlessly.
